### PR TITLE
feat: Remove rarely used Author Checklist section from PR Template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,14 +4,3 @@
 
 # Forecast Ticket Link(s)
 
-
-
-<details>
-    <summary><h4>Author Checklist</h4></summary>
-
-- [ ]  Non code change
-- [ ]  Followed DRY (Don't repeat yourself)
-- [ ]  Dependency Updates
-- [ ]  Migrations Required
-- [ ]  Added tests
-</details>


### PR DESCRIPTION
# Changes Summary

I rarely see this get used in the PR body, so removing of the sake of compacting down the feed in the #Engineers PR room in teams. 